### PR TITLE
fixed minor doc typos (spaces within words)

### DIFF
--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -14,11 +14,11 @@
 #   Default: 99
 #
 # [*system*]
-#   Boolean.  Whether or not the certificate should be installedi n the system keychain
+#   Boolean.  Whether or not the certificate should be installed in the system keychain
 #   Default: true
 #
 # [*java*]
-#   Boolean.  Whether or not the certificate should be installedi n the java keychain
+#   Boolean.  Whether or not the certificate should be installed in the java keychain
 #   Default: true
 #
 #


### PR DESCRIPTION
I noticed these minor typos while preparing a new feature (java_keystore: expect PR soon)
