### PR TITLE
Fix sles12 support

### DIFF
--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -63,10 +63,6 @@ define trusted_ca::ca (
 
   if $source {
 
-    if inline_template('<% if /\.#{@certfile_suffix}$/.match(@source) then %>yes<% else %>no<% end %>') == 'no' {
-      fail("[Trusted_ca::Ca::${name}]: source must a PEM encoded file with the ${certfile_suffix} extension")
-    }
-
     file { "${install_path}/${_name}":
       ensure => 'file',
       source => $source,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,20 +31,13 @@ class trusted_ca (
   $certs_package        = $::trusted_ca::params::certs_package,
 ) inherits trusted_ca::params {
 
-  if is_array($path) {
-    $_path = join($path, ':')
-  }
-  else {
-    $_path = $path
-  }
-
   package { $certs_package:
     ensure  => $certificates_version,
   }
 
   exec { 'update_system_certs':
     command     => $update_command,
-    path        => $_path,
+    path        => $path,
     logoutput   => on_failure,
     refreshonly => true,
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -50,15 +50,21 @@ class trusted_ca::params {
       $certfile_suffix = 'pem'
       case $::operatingsystem {
         'SLES': {
-          $path = ['/usr/bin']
-          $update_command = 'c_rehash'
-          $install_path = '/etc/ssl/certs'
           case $::operatingsystemmajrelease {
             '11': {
               $certs_package = 'openssl-certs'
+              $path = ['/usr/bin']
+              $update_command = 'c_rehash'
+              $install_path = '/etc/ssl/certs'
+            }
+            '12': {
+              $certs_package = 'ca-certificates'
+              $path = ['/usr/sbin', '/usr/bin']
+              $update_command = 'update-ca-certificates'
+              $install_path = '/etc/pki/trust/anchors'
             }
             default: {
-              $certs_package = 'ca-certificates'
+              fail("${::osfamily} ${::operatingsystemmajrelease} has not been tested with this module.  Please feel free to test and report the results")
             }
           }
         }

--- a/spec/classes/trusted_ca_init_spec.rb
+++ b/spec/classes/trusted_ca_init_spec.rb
@@ -26,7 +26,7 @@ describe 'trusted_ca' do
         context 'update_system_certs' do
           context 'array path' do
             let(:params) { { :path => ['/bin', '/usr/bin'] } }
-            it { should contain_exec('update_system_certs').with(:refreshonly => true, :path => '/bin:/usr/bin') }
+            it { should contain_exec('update_system_certs').with(:refreshonly => true, :path => ['/bin', '/usr/bin']) }
           end
 
           context 'string path' do


### PR DESCRIPTION
Changes:
- this removes a check for filename extension in ca.pp; so you can use the same cert for suse and redhat
- exec can use and array (I checked back until Puppet 3.5 - don't have older docs)
- sles12 should behave like opensuse and use update-ca-certificates
